### PR TITLE
add nuget publishing scripts and release docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,6 @@ PRIME_SIGNING_KEY=your-signing-key
 # Optional IDs for examples
 PRIME_ENTITY_ID=your-entity-id
 PRIME_PORTFOLIO_ID=your-portfolio-id
+
+# Required for scripts/release.sh (NuGet publish)
+NUGET_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ generated/
 [Bb]in/
 [Oo]bj/
 *.nupkg
+artifacts/
 
 # user
 *.user

--- a/README.md
+++ b/README.md
@@ -82,6 +82,29 @@ To build the sample library, ensure that [.NET 10 SDK](https://dotnet.microsoft.
 dotnet build prime-sdk-dotnet.sln
 ```
 
+## Release (NuGet)
+
+Releases only the **`CoinbaseSdk.Prime`** package ([`src/CoinbaseSdk/Prime/CoinbaseSdk.Prime.csproj`](src/CoinbaseSdk/Prime/CoinbaseSdk.Prime.csproj)) — not `PrimeExample`, `tools/generator`, or other projects.
+
+Maintainers: publish a new package version from the terminal on `main` with a clean working tree.
+
+1. Create a NuGet API key at [nuget.org](https://www.nuget.org/account/apikeys) scoped to package `CoinbaseSdk.Prime` (or your org’s scope).
+2. Set `NUGET_API_KEY` in `.env` (see [`.env.example`](.env.example)) or `export` it in the shell. On macOS you can also store the key in the keychain (service `nuget-coinbase-prime`); `scripts/release.sh` reads it if `NUGET_API_KEY` is unset:
+
+   ```bash
+   security add-generic-password -s nuget-coinbase-prime -a "$(whoami)" -w "YOUR_NUGET_API_KEY"
+   ```
+
+3. Run the release script (from repo root), passing the new semver. You will be prompted before pushing to nuget.org and before committing/tagging.
+
+   ```bash
+   ./scripts/release.sh 0.6.0
+   ```
+
+- Non-interactive (e.g. automation): set `RELEASE_NO_CONFIRM=1`.
+- By default the scripts restore, build, and pack **only** `CoinbaseSdk.Prime` (no live API). Set `RUN_INTEGRATION_TESTS=1` to also run [integration tests](src/CoinbaseSdk/Prime.IntegrationTests) first (requires Prime credentials in `.env`; may fail on API or account permissions).
+- Pack and test only (outputs under `./artifacts/` without publishing): `./scripts/pack-local.sh` or `./scripts/pack-local.sh 0.6.0` to set `<Version>` first.
+
 ## Examples
 
 Each example under `src/CoinbaseSdk/PrimeExample/examples/` is a standalone `.cs` file executable directly with .NET 10+:

--- a/scripts/pack-local.sh
+++ b/scripts/pack-local.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Build and pack to ./artifacts for local inspection (or push to a local feed).
+# Optional: pass a version to set <Version> in the csproj first (revert with git checkout if only testing).
+# Usage: ./scripts/pack-local.sh [semver]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Only CoinbaseSdk.Prime is packed (not other repo projects).
+CSPROJ="src/CoinbaseSdk/Prime/CoinbaseSdk.Prime.csproj"
+INTEGRATION_TESTS="src/CoinbaseSdk/Prime.IntegrationTests/CoinbaseSdk.Prime.IntegrationTests.csproj"
+
+if [[ -n "${1-}" ]]; then
+  VERSION="$1"
+  if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+    echo "Invalid version: $VERSION" >&2
+    exit 1
+  fi
+  sed -i '' "s|<Version>.*</Version>|<Version>${VERSION}</Version>|" "$CSPROJ"
+  echo "Set $CSPROJ to Version $VERSION (revert: git checkout -- $CSPROJ)"
+fi
+
+mkdir -p artifacts
+dotnet restore "$CSPROJ"
+if [[ "${RUN_INTEGRATION_TESTS:-}" == "1" ]]; then
+  dotnet test "$INTEGRATION_TESTS" -c Release
+else
+  dotnet build "$CSPROJ" -c Release
+fi
+dotnet pack "$CSPROJ" -c Release -o ./artifacts
+echo "Packed under ./artifacts/"
+ls -la ./artifacts/

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Bump version, test, pack, push to nuget.org, then commit, tag, and push to origin.
+# Usage: ./scripts/release.sh <semver>
+# Set NUGET_API_KEY in .env, environment, or macOS keychain (service: nuget-coinbase-prime).
+# Set RELEASE_NO_CONFIRM=1 to skip "Are you sure?" prompts (e.g. CI).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Only this project is packed and published to NuGet (not PrimeExample, generator, etc.)
+CSPROJ="src/CoinbaseSdk/Prime/CoinbaseSdk.Prime.csproj"
+INTEGRATION_TESTS="src/CoinbaseSdk/Prime.IntegrationTests/CoinbaseSdk.Prime.IntegrationTests.csproj"
+NUGET_SOURCE="https://api.nuget.org/v3/index.json"
+KEYCHAIN_SERVICE="nuget-coinbase-prime"
+
+if [[ -z "${1-}" ]]; then
+  echo "Usage: $0 <semver>  (e.g. 0.6.0 or 1.0.0-rc.1)" >&2
+  exit 1
+fi
+VERSION="$1"
+
+# Semver: major.minor.patch, optional -prerelease (alphanumeric, dots)
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+  echo "Invalid version: $VERSION (expected e.g. 0.6.0 or 1.0.0-beta.1)" >&2
+  exit 1
+fi
+
+confirm() {
+  if [[ "${RELEASE_NO_CONFIRM:-}" == "1" ]]; then
+    return 0
+  fi
+  if [[ ! -t 0 ]]; then
+    echo "Not a TTY; set RELEASE_NO_CONFIRM=1 to continue." >&2
+    return 1
+  fi
+  read -r -p "$1 [y/N] " reply
+  case "$reply" in
+    [yY]|[yY][eE][sS]) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# --- Load NUGET_API_KEY ---
+if [[ -z "${NUGET_API_KEY:-}" && -f .env ]]; then
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+    if [[ "$line" == NUGET_API_KEY=* ]]; then
+      export NUGET_API_KEY="${line#NUGET_API_KEY=}"
+      # Trim optional surrounding double quotes
+      NUGET_API_KEY="${NUGET_API_KEY%\"}"; NUGET_API_KEY="${NUGET_API_KEY#\"}"
+      export NUGET_API_KEY
+      break
+    fi
+  done < .env
+fi
+if [[ -z "${NUGET_API_KEY:-}" ]]; then
+  if k="$(security find-generic-password -s "$KEYCHAIN_SERVICE" -w 2>/dev/null)"; then
+    export NUGET_API_KEY="$k"
+  fi
+fi
+if [[ -z "${NUGET_API_KEY:-}" ]]; then
+  echo "NUGET_API_KEY is not set. Add it to .env, export it, or store in keychain:" >&2
+  echo "  security add-generic-password -s $KEYCHAIN_SERVICE -a \$(whoami) -w <key>" >&2
+  exit 1
+fi
+
+# --- Git guards ---
+if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
+  echo "Working tree is not clean. Commit or stash changes first." >&2
+  exit 1
+fi
+current_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+if [[ "$current_branch" != "main" ]]; then
+  echo "Not on main (current: $current_branch). Switch to main before releasing." >&2
+  exit 1
+fi
+
+# --- Date for changelog (match existing style, e.g. 2026-APR-7) ---
+D=$(date +%d)
+M=$(date +%b | tr '[:lower:]' '[:upper:]')
+Y=$(date +%Y)
+CHANGELOG_DATE="${Y}-${M}-${D}"
+
+# --- Bump version in csproj ---
+if [[ ! -f "$CSPROJ" ]]; then
+  echo "Missing $CSPROJ" >&2
+  exit 1
+fi
+sed -i '' "s|<Version>.*</Version>|<Version>${VERSION}</Version>|" "$CSPROJ"
+
+# --- Changelog stub at top (after # Changelog) ---
+CHANGELOG="CHANGELOG.md"
+if [[ ! -f "$CHANGELOG" ]]; then
+  echo "Missing $CHANGELOG" >&2
+  exit 1
+fi
+TMPCL="$(mktemp)"
+{
+  head -1 "$CHANGELOG"
+  echo ""
+  {
+    echo "## [${VERSION}] - ${CHANGELOG_DATE}"
+    echo ""
+    echo "### Added"
+    echo ""
+    echo "- (Add release notes before the next tag)"
+  }
+  echo ""
+  tail -n +2 "$CHANGELOG"
+} >"$TMPCL"
+mv "$TMPCL" "$CHANGELOG"
+
+# --- Build & pack (core package only) ---
+# Default: restore/build/pack CoinbaseSdk.Prime only. Set RUN_INTEGRATION_TESTS=1 to also run
+# integration tests against the live API (requires .env; may fail on API or permissions).
+mkdir -p artifacts
+dotnet restore "$CSPROJ"
+if [[ "${RUN_INTEGRATION_TESTS:-}" == "1" ]]; then
+  dotnet test "$INTEGRATION_TESTS" -c Release
+else
+  dotnet build "$CSPROJ" -c Release
+fi
+dotnet pack "$CSPROJ" -c Release -o ./artifacts
+
+NUPKG="./artifacts/CoinbaseSdk.Prime.${VERSION}.nupkg"
+if [[ ! -f "$NUPKG" ]]; then
+  echo "Expected package not found: $NUPKG" >&2
+  exit 1
+fi
+
+# --- Push to NuGet ---
+if ! confirm "Push $NUPKG to nuget.org?"; then
+  echo "Aborted. Revert with: git checkout -- $CSPROJ $CHANGELOG" >&2
+  exit 1
+fi
+dotnet nuget push "$NUPKG" --api-key "$NUGET_API_KEY" --source "$NUGET_SOURCE" --skip-duplicate
+
+# --- Commit, tag, push git ---
+if ! confirm "Create commit, tag v${VERSION}, and push to origin?"; then
+  echo "Package published. Commit/tag manually; working tree has version + changelog changes." >&2
+  exit 0
+fi
+git add "$CSPROJ" "$CHANGELOG"
+git commit -m "chore: release v${VERSION}"
+if git rev-parse "v${VERSION}" >/dev/null 2>&1; then
+  echo "Tag v${VERSION} already exists. Delete it or pick another version." >&2
+  exit 1
+fi
+git tag "v${VERSION}"
+git push
+git push --tags
+echo "Done. Released v${VERSION} to NuGet and pushed tag."


### PR DESCRIPTION
## Summary
- Adds `scripts/release.sh` for tagging releases and pushing packages to NuGet
- Adds `scripts/pack-local.sh` for building and testing packages locally before publishing
- Documents the publishing workflow and required environment variables in the README
- Adds `NUGET_API_KEY` to `.env.example`
- Adds `*.nupkg` to `.gitignore`

## Impacted modules
- `scripts/`
- `README.md`
- `.env.example`
- `.gitignore`

## Test plan
- [ ] Run `scripts/pack-local.sh` and verify `.nupkg` is generated correctly
- [ ] Dry-run `scripts/release.sh` against a test NuGet feed to verify publish flow

## Follow-up
- None

Made with [Cursor](https://cursor.com)