### PR TITLE
chore: deprecate samples repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@
 - **`CoinbasePrimeClient`**: Optional `IJsonUtility` injection; `WithApiBasePath()` and `WithApiVersion()` for versioned base paths
 - **`Pagination.Builder`**: Builder methods renamed to `WithNextCursor`, `WithSortDirection`, `WithHasNext`
 
+### Notes
+
+- This repository is deprecated; development continues at [coinbase/prime-sdk-dotnet](https://github.com/coinbase/prime-sdk-dotnet). NuGet releases **0.7.0+** are published from the canonical repository.
+
 ### Removed
 
 - **`PortfoliosService.GetPortfolioCounterparty`**: Use **`AdvancedTransferService.GetPortfolioCounterparty`** instead

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Coinbase Prime .NET SDK
 
-The canonical source repository is **[coinbase/prime-sdk-dotnet](https://github.com/coinbase/prime-sdk-dotnet)**. The former [coinbase-samples/prime-sdk-dotnet](https://github.com/coinbase-samples/prime-sdk-dotnet) repository is deprecated. NuGet releases **0.7.0+** are published from the canonical repository. The package ID is unchanged (`CoinbaseSdk.Prime`).
+> **Deprecated:** This repository has moved to [github.com/coinbase/prime-sdk-dotnet](https://github.com/coinbase/prime-sdk-dotnet).
+> Install with `dotnet add package CoinbaseSdk.Prime`. The package ID is unchanged; NuGet releases **0.7.0+** are published from the canonical repository.
+> This repository is no longer maintained.
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Coinbase Prime .NET SDK
 
+The canonical source repository is **[coinbase/prime-sdk-dotnet](https://github.com/coinbase/prime-sdk-dotnet)**. The former [coinbase-samples/prime-sdk-dotnet](https://github.com/coinbase-samples/prime-sdk-dotnet) repository is deprecated. NuGet releases **0.7.0+** are published from the canonical repository. The package ID is unchanged (`CoinbaseSdk.Prime`).
+
 ## Overview
 
 The _Coinbase Prime .NET SDK_ is a sample library that demonstrates the structure of a [Coinbase Prime](https://prime.coinbase.com/) driver for the [REST APIs](https://docs.cdp.coinbase.com/prime/reference).
@@ -115,7 +117,7 @@ If you discover a security vulnerability within this SDK, please see our [Securi
 
 ## 📧 Contact
 
-- [GitHub Issues](https://github.com/coinbase-samples/prime-sdk-dotnet/issues)
+- [GitHub Issues](https://github.com/coinbase/prime-sdk-dotnet/issues)
 
 ## License
 


### PR DESCRIPTION
## Summary
- Add deprecation banner to README pointing at coinbase/prime-sdk-dotnet
- Update GitHub Issues link to the canonical repository
- Note repository deprecation under CHANGELOG 0.6.0

## Testing
- Documentation-only change; no build or test impact

## Notes
- No version bump, tag, or NuGet publish from samples
- Part of migration to coinbase/prime-sdk-dotnet (0.7.0+ on NuGet from canonical repo)

Change management: type=routine risk=low impact=sev5